### PR TITLE
fix: test code

### DIFF
--- a/test/test_departure_button_lamp_manager.cpp
+++ b/test/test_departure_button_lamp_manager.cpp
@@ -115,3 +115,4 @@ TEST_F(DepartureButtonLampManagerTest, TestAllStateCombinations)
       }
     }
   }
+}


### PR DESCRIPTION
## description
#1でテストコードによってcolcon buildが出来ない状態であったため、コードを修正しました
## Review procedure
colcon buildとtestが通ることを確認済み

build
`colcon build  --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select departure_button_lamp_manager`

![image](https://github.com/user-attachments/assets/c3417830-b4b8-4597-9017-cb46c15f064b)

test
```bash
colcon test --packages-select departure_button_lamp_manager --event-handlers console_cohesion+            
Starting >>> departure_button_lamp_manager
--- output: departure_button_lamp_manager                   
UpdateCTestConfiguration  from :/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Parse Config file:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
   Site: dpc2406506
   Build name: (empty)
 Add coverage exclude regular expressions.
Create new tag: 20241119-0433 - Experimental
UpdateCTestConfiguration  from :/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Parse Config file:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Test project /home/rikukimura/unit_ws/build/departure_button_lamp_manager
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: test_departure_button_lamp_manager

1: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml" "--package-name" "departure_button_lamp_manager" "--output-file" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/ament_cmake_gtest/test_departure_button_lamp_manager.txt" "--command" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_departure_button_lamp_manager" "--gtest_output=xml:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/home/rikukimura/unit_ws/build/departure_button_lamp_manager':
1:  - /home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_departure_button_lamp_manager --gtest_output=xml:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml
1: Running main() from /opt/ros/humble/src/gtest_vendor/src/gtest_main.cc
1: [==========] Running 1 test from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 1 test from DepartureButtonLampManagerTest
1: [ RUN      ] DepartureButtonLampManagerTest.TestAllStateCombinations
1: [INFO 1731990822.405147995] [departure_button_lamp_manager] callbackStateMessage(): "[DepartureButtonLampManager::callbackStateMessage]service_layer_state: 0, control_layer_state: 0" at (/home/rikukimura/unit_ws/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp:L43)
1: [       OK ] DepartureButtonLampManagerTest.TestAllStateCombinations (11 ms)
1: [----------] 1 test from DepartureButtonLampManagerTest (11 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 1 test from 1 test suite ran. (11 ms total)
1: [  PASSED  ] 1 test.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file '/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml'
1: -- run_test.py: verify result file '/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml'
1/1 Test #1: test_departure_button_lamp_manager ...   Passed    0.08 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
gtest    =   0.08 sec*proc (1 test)

Total Test time (real) =   0.09 sec
---
Finished <<< departure_button_lamp_manager [0.15s]

Summary: 1 package finished [0.31s]
```