### PR TITLE
fix: add specific process test code 

### DIFF
--- a/test/test_departure_button_lamp_manager.cpp
+++ b/test/test_departure_button_lamp_manager.cpp
@@ -59,11 +59,11 @@ protected:
 
     ASSERT_FALSE(received_messages_.empty())
       << "Message not received for service_state=" << service_state
-      << ", control_state=" << control_state;
+      << ", control_state=" << static_cast<int>(control_state);
 
     bool actual_value = received_messages_.front().value;
     EXPECT_EQ(actual_value, expected_value)
-      << "service_state=" << service_state << ", control_state=" << control_state
+      << "service_state=" << service_state << ", control_state=" << static_cast<int>(control_state)
       << ", expected=" << expected_value << ", actual=" << actual_value;
     std::cout << "service_layer_state: " << msg.service_layer_state << std::endl;
     std::cout << "control_layer_state: " << static_cast<int>(msg.control_layer_state) << std::endl;

--- a/test/test_departure_button_lamp_manager.cpp
+++ b/test/test_departure_button_lamp_manager.cpp
@@ -65,6 +65,8 @@ protected:
     EXPECT_EQ(actual_value, expected_value)
       << "service_state=" << service_state << ", control_state=" << control_state
       << ", expected=" << expected_value << ", actual=" << actual_value;
+    std::cout << "service_layer_state: " << msg.service_layer_state << std::endl;
+    std::cout << "control_layer_state: " << static_cast<int>(msg.control_layer_state) << std::endl;
   }
 
   rclcpp::Node::SharedPtr node_;
@@ -105,6 +107,8 @@ TEST_F(DepartureButtonLampManagerTest, TestAllStateCombinations)
       StateMachine::AUTO
     };
 
+    // check all state combinations
+    std::cout << "normal test start" << std::endl;
     for (auto service_state : service_states) {
       for (auto control_state : control_states) {
         bool expected_value =
@@ -114,4 +118,33 @@ TEST_F(DepartureButtonLampManagerTest, TestAllStateCombinations)
           expected_value);
       }
     }
+
+    // check specific state combinations
+    auto previous_service_state = StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION;
+    std::cout << "specific test start" << std::endl;
+    for (auto service_state : service_states) {
+      for (auto control_state : control_states) {
+
+        bool previous_expected_value =
+          !(previous_service_state == StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION && control_state == StateMachine::AUTO);
+        
+        bool expected_value =
+          !(service_state == StateMachine::STATE_WAITING_CALL_PERMISSION && control_state == StateMachine::AUTO);
+        if (service_state == StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION && control_state == StateMachine::AUTO){
+          expected_value = false;
+        }
+        // error handling
+        sendAndCheckMessage(
+          static_cast<uint16_t>(previous_service_state), static_cast<uint8_t>(control_state),
+          previous_expected_value);
+        
+        // for STATE_WAITING_CALL_PERMISSION 
+        sendAndCheckMessage(
+          static_cast<uint16_t>(service_state), static_cast<uint8_t>(control_state),
+          expected_value);
+          
+      }
+    }
+
   }
+}


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links
https://tier4.atlassian.net/browse/AEAP-2040
https://star4.slack.com/archives/C04CKSQ7ZFZ/p1734326038901919?thread_ts=1734074124.960549&cid=C04CKSQ7ZFZ
<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
本PRでは、v4.4.0のリリーステスト中に発生した発進可能状態で発進ボタンランプが消灯する問題のテストコードのみを修正したものになります。
上記が発生している原因として、自動運転の状態が「発進指示待ち(`STATE_WAITING_ENGAGE_INSTRUCTION`)」かつ車両のメインスイッチキーが「自動」なら発進ボタンLEDを点灯させる。といった要件に対して`STATE_WAITING_ENGAGE_INSTRUCTION`から`STATE_WAITING_CALL_PERMISSION`へと遷移する場合の定義漏れがあったことに起因しています。
そのため、上記の場合にも発進可能状態でLEDを点灯させる処理を追加します。

このPRではソースコードを変更せずに修正したテストコードでエラーが出ることを確認しています。

<!-- Describe what this PR changes. -->

## Review Procedure
### テストコード内容
既存のテストに追記で特定の状態でのテストを追加しています。
内容として、直前の`autoware_state_machine`の`service_layer_state`を`STATE_WAITING_ENGAGE_INSTRUCTION`であると仮定し、その次の`STATE_WAITING_CALL_PERMISSION`となった場合にもLEDが点灯状態(false)となるか確認するためのテストコードを追記しています。
以下追加内容
- テストデバッグ用の出力に関する追記
- `STATE_WAITING_CALL_PERMISSION`のテスト用の追記

### local test結果
![image](https://github.com/user-attachments/assets/46c94d27-8745-4747-8dac-3be0b54ec32c)
出力結果から、直前の`service_layer_state`が`STATE_WAITING_ENGAGE_INSTRUCTION(201)`かつ、`control_layer_state`が`AUTO`となった次に`service_layer_state`が`STATE_WAITING_CALL_PERMISSION(250)`かつ、`control_layer_state`が`AUTO`へ状態遷移したらエラーが出力されることを確認しました。

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer
- [ ] (If you added new repositories to `.repos`) set permissions for each repository.
      You need to add the following permissions to each github team in the new repository according to [this][repository-permission-setting-flow].
  - READ:
    - eve-autonomy

  - WRITE:
    - full-time-employee

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes
- [ ] (When added something to `.repos`) Check if proper access rights are set.
      You can check the latest permission setting status of each repository [here][github-repository-status].
      If the repository permissions are insufficient, you need to add the permissions according to [this][repository-permission-setting-flow].

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **vcs import**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute

<!-- Additional links -->

[github-repository-status]: https://docs.google.com/spreadsheets/d/13L1kVWpU5aI_sQIRCR_xk-DuVAK-B4lqkY_xAPWJ-MY/edit#gid=0
[repository-permission-setting-flow]: https://tier4.atlassian.net/wiki/spaces/T4MANUALS/pages/930546509/GitHub+Flow