### PR TITLE
fix: test_code

### DIFF
--- a/test/test_departure_button_lamp_manager.cpp
+++ b/test/test_departure_button_lamp_manager.cpp
@@ -108,7 +108,8 @@ TEST_F(DepartureButtonLampManagerTest, TestAllStateCombinations)
     for (auto service_state : service_states) {
       for (auto control_state : control_states) {
         bool expected_value =
-          !(service_state == StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION && control_state == StateMachine::AUTO);
+          !((service_state == StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION ||
+            service_state == StateMachine::STATE_WAITING_CALL_PERMISSION)&& control_state == StateMachine::AUTO);
         sendAndCheckMessage(
           static_cast<uint16_t>(service_state), static_cast<uint8_t>(control_state),
           expected_value);


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links
[INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-2040)


<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
STATE_WAITING_CALL_PERMISSIONに発進ボタンledが光らない不具合が発見された。
上記不具合については、
「STATE_WAITING_CALL_PERMISSIONの際には、発進ボタンが光ること」が仕様漏れのため、テストコードとソースコード両方を修正する必要がある。
このPRでは、テストコードを修正する。


<!-- Describe what this PR changes. -->


## Review Procedure
1.buildする

`colcon build  --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select departure_button_lamp_manager`
2.既存のソースコードでtestを実施
(STATE_WAITING_CALL_PERMISSIONの際にfailedすることを確認済み。)
`
colcon test --packages-select departure_button_lamp_manager --event-handlers console_cohesion+  
`
<details>

```bash
colcon test --packages-select departure_button_lamp_manager --event-handlers console_cohesion+                                                                                                          [19:29:17]

Starting >>> departure_button_lamp_manager
--- output: departure_button_lamp_manager                   
UpdateCTestConfiguration  from :/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Parse Config file:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
   Site: npc2308011
   Build name: (empty)
 Add coverage exclude regular expressions.
Create new tag: 20241216-1029 - Experimental
UpdateCTestConfiguration  from :/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Parse Config file:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Test project /home/rikukimura/unit_ws/build/departure_button_lamp_manager
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: test_departure_button_lamp_manager

1: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml" "--package-name" "departure_button_lamp_manager" "--output-file" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/ament_cmake_gtest/test_departure_button_lamp_manager.txt" "--command" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_departure_button_lamp_manager" "--gtest_output=xml:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/home/rikukimura/unit_ws/build/departure_button_lamp_manager':
1:  - /home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_departure_button_lamp_manager --gtest_output=xml:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml
1: Running main() from /opt/ros/humble/src/gtest_vendor/src/gtest_main.cc
1: [==========] Running 1 test from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 1 test from DepartureButtonLampManagerTest
1: [ RUN      ] DepartureButtonLampManagerTest.TestAllStateCombinations
1: [INFO 1734344958.476056212] [departure_button_lamp_manager] callbackStateMessage(): "[DepartureButtonLampManager::callbackStateMessage]service_layer_state: 0, control_layer_state: 0" at (/home/rikukimura/unit_ws/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp:L43)
1: /home/rikukimura/unit_ws/departure_button_lamp_manager/test/test_departure_button_lamp_manager.cpp:65: Failure
1: Expected equality of these values:
1:   actual_value
1:     Which is: true
1:   expected_value
1:     Which is: false
1: service_state=250, control_state=, expected=false, actual=true
1: [INFO 1734344958.477064998] [departure_button_lamp_manager] callbackStateMessage(): "[DepartureButtonLampManager::callbackStateMessage]service_layer_state: 404, control_layer_state: 1" at (/home/rikukimura/unit_ws/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp:L43)
1: [  FAILED  ] DepartureButtonLampManagerTest.TestAllStateCombinations (10 ms)
1: [----------] 1 test from DepartureButtonLampManagerTest (10 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 1 test from 1 test suite ran. (10 ms total)
1: [  PASSED  ] 0 tests.
1: [  FAILED  ] 1 test, listed below:
1: [  FAILED  ] DepartureButtonLampManagerTest.TestAllStateCombinations
1: 
1:  1 FAILED TEST
1: -- run_test.py: return code 1
1: -- run_test.py: inject classname prefix into gtest result file '/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml'
1: -- run_test.py: verify result file '/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml'
1/1 Test #1: test_departure_button_lamp_manager ...***Failed    0.10 sec

0% tests passed, 1 tests failed out of 1

Label Time Summary:
gtest    =   0.10 sec*proc (1 test)

Total Test time (real) =   0.10 sec

The following tests FAILED:
	  1 - test_departure_button_lamp_manager (Failed)
Errors while running CTest
Output from these tests are in: /home/rikukimura/unit_ws/build/departure_button_lamp_manager/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
---
--- stderr: departure_button_lamp_manager
Errors while running CTest
Output from these tests are in: /home/rikukimura/unit_ws/build/departure_button_lamp_manager/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
---
Finished <<< departure_button_lamp_manager [0.18s]	[ with test failures ]

Summary: 1 package finished [0.41s]
  1 package had stderr output: departure_button_lamp_manager
  1 package had test failures: departure_button_lamp_manager

```
</details>

![image](https://github.com/user-attachments/assets/24faa9b0-9e21-4a2a-84e3-069e219be21a)

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer


## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes


## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
