### PR TITLE
fix: add service_layer_state STATE_WAITING_CALL_PERMISSION

### DIFF
--- a/src/departure_button_lamp_manager.cpp
+++ b/src/departure_button_lamp_manager.cpp
@@ -61,8 +61,9 @@ void DepartureButtonLampManager::lampManager(
   const uint16_t service_layer_state, const uint8_t control_layer_state)
 {
   if (
-    service_layer_state ==
-      autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION &&
+    (service_layer_state ==
+      autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION || 
+      service_layer_state == autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION) &&
     control_layer_state == autoware_state_machine_msgs::msg::StateMachine::AUTO) {
     publishLampState(true);
   } else {


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links
[INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-2040)


<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
STATE_WAITING_CALL_PERMISSIONに発進ボタンledが光らない不具合が発見された。
上記不具合については、
「STATE_WAITING_CALL_PERMISSIONの際には、発進ボタンが光ること」が仕様漏れのため、テストコードとソースコード両方を修正する必要がある。
このPRでは、ソースコードを修正する。


<!-- Describe what this PR changes. -->


## Review Procedure
1.buildする

`colcon build  --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select departure_button_lamp_manager`
2.既存のソースコードでtestを実施
(STATE_WAITING_CALL_PERMISSIONの際にもpassedすることを確認済み。)
`
colcon test --packages-select departure_button_lamp_manager --event-handlers console_cohesion+  
`
<details>

```bash
colcon test --packages-select departure_button_lamp_manager --event-handlers console_cohesion+     
Starting >>> departure_button_lamp_manager
--- output: departure_button_lamp_manager                   
UpdateCTestConfiguration  from :/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Parse Config file:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
   Site: npc2308011
   Build name: (empty)
 Add coverage exclude regular expressions.
Create new tag: 20241216-1118 - Experimental
UpdateCTestConfiguration  from :/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Parse Config file:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/CTestConfiguration.ini
Test project /home/rikukimura/unit_ws/build/departure_button_lamp_manager
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: test_departure_button_lamp_manager

1: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml" "--package-name" "departure_button_lamp_manager" "--output-file" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/ament_cmake_gtest/test_departure_button_lamp_manager.txt" "--command" "/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_departure_button_lamp_manager" "--gtest_output=xml:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/home/rikukimura/unit_ws/build/departure_button_lamp_manager':
1:  - /home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_departure_button_lamp_manager --gtest_output=xml:/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml
1: Running main() from /opt/ros/humble/src/gtest_vendor/src/gtest_main.cc
1: [==========] Running 1 test from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 1 test from DepartureButtonLampManagerTest
1: [ RUN      ] DepartureButtonLampManagerTest.TestAllStateCombinations
1: [INFO 1734347900.280080174] [departure_button_lamp_manager] callbackStateMessage(): "[DepartureButtonLampManager::callbackStateMessage]service_layer_state: 0, control_layer_state: 0" at (/home/rikukimura/unit_ws/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp:L43)
1: [INFO 1734347900.281086013] [departure_button_lamp_manager] callbackStateMessage(): "[DepartureButtonLampManager::callbackStateMessage]service_layer_state: 500, control_layer_state: 0" at (/home/rikukimura/unit_ws/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp:L43)
1: [       OK ] DepartureButtonLampManagerTest.TestAllStateCombinations (10 ms)
1: [----------] 1 test from DepartureButtonLampManagerTest (10 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 1 test from 1 test suite ran. (10 ms total)
1: [  PASSED  ] 1 test.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file '/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml'
1: -- run_test.py: verify result file '/home/rikukimura/unit_ws/build/departure_button_lamp_manager/test_results/departure_button_lamp_manager/test_departure_button_lamp_manager.gtest.xml'
1/1 Test #1: test_departure_button_lamp_manager ...   Passed    0.11 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
gtest    =   0.11 sec*proc (1 test)

Total Test time (real) =   0.11 sec
---
Finished <<< departure_button_lamp_manager [0.19s]

Summary: 1 package finished [0.42s]
                                                                                                     
```
</details>

![image](https://github.com/user-attachments/assets/5fae799e-b875-45a1-adf5-2a5f3274872f)


<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer


## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes


## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
