### PR TITLE
Ci/add pre commit test (#8)

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          repository: ${{ github.event.pull_request.head.repo.full_name }}  
-          ref: ${{ github.event.pull_request.head.ref }}  
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
@@ -34,7 +34,7 @@ jobs:
         run: |
           apt-get update -yqq
           apt-get install -yqq libboost-system-dev libboost-filesystem-dev libboost-thread-dev
-      
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,9 @@
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md for all rules.
+default: true
+MD013: false
+MD024:
+  siblings_only: true
+MD033: false
+MD041: false
+MD046: false
+MD049: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,71 @@
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines in its README.
+
+# https://pre-commit.ci/#configuration
+ci:
+  autofix_commit_msg: "style(pre-commit): autofix"
+  # we already have our own daily update mechanism, we set this to quarterly
+  autoupdate_schedule: quarterly
+  autoupdate_commit_msg: "ci(pre-commit): quarterly autoupdate"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+        args: [--unsafe]
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.43.0
+    hooks:
+      - id: markdownlint
+        args: [-c, .markdownlint.yaml, --fix]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/tier4/pre-commit-hooks-ros
+    rev: v0.10.0
+    hooks:
+      - id: flake8-ros
+      - id: prettier-xacro
+      - id: prettier-launch-xml
+      - id: prettier-package-xml
+      - id: ros-include-guard
+      - id: sort-package-xml
+
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: [--line-length=100]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.5
+    hooks:
+      - id: clang-format
+        types_or: [c++, c, cuda]
+
+  - repo: https://github.com/cpplint/cpplint
+    rev: 2.0.0
+    hooks:
+      - id: cpplint
+        args: [--quiet]
+        exclude: .cu

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,20 @@
+printWidth: 100
+tabWidth: 2
+overrides:
+  - files: package.xml
+    options:
+      printWidth: 1000
+      xmlSelfClosingSpace: false
+      xmlWhitespaceSensitivity: ignore
+
+  - files: "*.launch.xml"
+    options:
+      printWidth: 200
+      xmlSelfClosingSpace: false
+      xmlWhitespaceSensitivity: ignore
+
+  - files: "*.xacro"
+    options:
+      printWidth: 200
+      xmlSelfClosingSpace: false
+      xmlWhitespaceSensitivity: ignore

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # departure_button_lamp_manager
 
 ## Overview
+
 This node controls departure LED lamp for logistics workers turough `/dio_ros_driver` to inform if the vehicle is able to departure.
 
-# Input and Output
+## Input and Output
 
 - Input
-    - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine_msgs/tree/main)
-    - `/autoware_state_machine/state` \[[autoware_state_machine_msgs/msg/StateMachine](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateMachine.msg)\]:<br>State of the system.
+  - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine_msgs/tree/main)
+  - `/autoware_state_machine/state` \[[autoware_state_machine_msgs/msg/StateMachine](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateMachine.msg)\]:<br>State of the system.
 - output
   - to [dio_ros_driver](https://github.com/tier4/dio_ros_driver/)
-    - `/dio/dout4`  \[[dio_ros_driver/msg/DIOPort](https://github.com/tier4/dio_ros_driver/blob/develop/ros2/msg/DIOPort.msg)\]:<br>GPIO output topic for departure lamp. (this topic is remapping from button_lamp_out)
+    - `/dio/dout4` \[[dio_ros_driver/msg/DIOPort](https://github.com/tier4/dio_ros_driver/blob/develop/ros2/msg/DIOPort.msg)\]:<br>GPIO output topic for departure lamp. (this topic is remapping from button_lamp_out)
+
 ## Node Graph
 
 ![node graph](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/eve-autonomy/departure_button_lamp_manager/main/docs/node_graph.pu)
-

--- a/departure_button_lamp_manager/CMakeLists.txt
+++ b/departure_button_lamp_manager/CMakeLists.txt
@@ -61,4 +61,3 @@ ament_export_dependencies(
 ament_auto_package(INSTALL_TO_SHARE
   launch
 )
-

--- a/departure_button_lamp_manager/include/departure_button_lamp_manager/departure_button_lamp_manager.hpp
+++ b/departure_button_lamp_manager/include/departure_button_lamp_manager/departure_button_lamp_manager.hpp
@@ -19,30 +19,31 @@
 #include "dio_ros_driver/msg/dio_port.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-namespace departure_button_lamp_manager
-{
-class DepartureButtonLampManager : public rclcpp::Node
-{
+namespace departure_button_lamp_manager {
+class DepartureButtonLampManager : public rclcpp::Node {
 public:
-  explicit DepartureButtonLampManager(const rclcpp::NodeOptions & options);
+  explicit DepartureButtonLampManager(const rclcpp::NodeOptions &options);
   ~DepartureButtonLampManager();
 
 private:
 #define ACTIVE_POLARITY (false)
 
   // Publisher
-  rclcpp::Publisher<dio_ros_driver::msg::DIOPort>::SharedPtr pub_departure_button_lamp_;
+  rclcpp::Publisher<dio_ros_driver::msg::DIOPort>::SharedPtr
+      pub_departure_button_lamp_;
 
   // Subscriber
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_state_;
+  rclcpp::Subscription<
+      autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_state_;
 
   bool active_polarity_;
 
   void callbackStateMessage(
-    const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg);
+      const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg);
   void publishLampState(const bool value);
-  void lampManager(const uint16_t service_layer_state, const uint8_t control_layer_state);
+  void lampManager(const uint16_t service_layer_state,
+                   const uint8_t control_layer_state);
 };
 
-}  // namespace departure_button_lamp_manager
-#endif  // DEPARTURE_BUTTON_LAMP_MANAGER__DEPARTURE_BUTTON_LAMP_MANAGER_HPP_
+} // namespace departure_button_lamp_manager
+#endif // DEPARTURE_BUTTON_LAMP_MANAGER__DEPARTURE_BUTTON_LAMP_MANAGER_HPP_

--- a/departure_button_lamp_manager/launch/departure_button_lamp_manager.launch.xml
+++ b/departure_button_lamp_manager/launch/departure_button_lamp_manager.launch.xml
@@ -13,11 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
 <launch>
-
   <node pkg="departure_button_lamp_manager" exec="departure_button_lamp_manager_node" name="departure_button_lamp_manager" output="screen">
-    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)" />
-    <remap from="button_lamp_out" to="/dio/dout4" />
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
+    <remap from="button_lamp_out" to="/dio/dout4"/>
   </node>
 </launch>

--- a/departure_button_lamp_manager/package.xml
+++ b/departure_button_lamp_manager/package.xml
@@ -24,12 +24,12 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>dio_ros_driver</depend>
   <depend>autoware_state_machine_msgs</depend>
-  <depend>rclcpp_components</depend>
- 
   <depend>builtin_interfaces</depend>
+  <depend>dio_ros_driver</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp
+++ b/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp
@@ -15,42 +15,43 @@
 #include <departure_button_lamp_manager/departure_button_lamp_manager.hpp>
 #include <fstream>
 
-namespace departure_button_lamp_manager
-{
+namespace departure_button_lamp_manager {
 
 DepartureButtonLampManager::DepartureButtonLampManager(
-  const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
-: Node("departure_button_lamp_manager", options)
+    const rclcpp::NodeOptions &options = rclcpp::NodeOptions())
+    : Node("departure_button_lamp_manager", options)
 
 {
   // subscriber
-  sub_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateMachine>(
-    "autoware_state_machine/state", rclcpp::QoS{3}.transient_local(),
-    std::bind(&DepartureButtonLampManager::callbackStateMessage, this, std::placeholders::_1));
+  sub_state_ =
+      this->create_subscription<autoware_state_machine_msgs::msg::StateMachine>(
+          "autoware_state_machine/state", rclcpp::QoS{3}.transient_local(),
+          std::bind(&DepartureButtonLampManager::callbackStateMessage, this,
+                    std::placeholders::_1));
 
   // publisher
-  pub_departure_button_lamp_ = this->create_publisher<dio_ros_driver::msg::DIOPort>(
-    "button_lamp_out", rclcpp::QoS{3}.transient_local());
+  pub_departure_button_lamp_ =
+      this->create_publisher<dio_ros_driver::msg::DIOPort>(
+          "button_lamp_out", rclcpp::QoS{3}.transient_local());
 
   active_polarity_ = ACTIVE_POLARITY;
 }
 
-DepartureButtonLampManager::~DepartureButtonLampManager() { publishLampState(false); }
+DepartureButtonLampManager::~DepartureButtonLampManager() {
+  publishLampState(false);
+}
 
 void DepartureButtonLampManager::callbackStateMessage(
-  const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg)
-{
-  RCLCPP_INFO_THROTTLE(
-    this->get_logger(), *this->get_clock(), 1.0,
-    "[DepartureButtonLampManager::callbackStateMessage]"
-    "service_layer_state: %u, control_layer_state: %u",
-    msg->service_layer_state, msg->control_layer_state);
+    const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg) {
+  RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1.0,
+                       "[DepartureButtonLampManager::callbackStateMessage]"
+                       "service_layer_state: %u, control_layer_state: %u",
+                       msg->service_layer_state, msg->control_layer_state);
 
   lampManager(msg->service_layer_state, msg->control_layer_state);
 }
 
-void DepartureButtonLampManager::publishLampState(const bool value)
-{
+void DepartureButtonLampManager::publishLampState(const bool value) {
   dio_ros_driver::msg::DIOPort msg;
   msg.value = active_polarity_ ? value : !value;
 
@@ -58,20 +59,21 @@ void DepartureButtonLampManager::publishLampState(const bool value)
 }
 
 void DepartureButtonLampManager::lampManager(
-  const uint16_t service_layer_state, const uint8_t control_layer_state)
-{
-  if (
-    (service_layer_state ==
-      autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION || 
-      service_layer_state == autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION) &&
-    control_layer_state == autoware_state_machine_msgs::msg::StateMachine::AUTO) {
+    const uint16_t service_layer_state, const uint8_t control_layer_state) {
+  if ((service_layer_state == autoware_state_machine_msgs::msg::StateMachine::
+                                  STATE_WAITING_ENGAGE_INSTRUCTION ||
+       service_layer_state == autoware_state_machine_msgs::msg::StateMachine::
+                                  STATE_WAITING_CALL_PERMISSION) &&
+      control_layer_state ==
+          autoware_state_machine_msgs::msg::StateMachine::AUTO) {
     publishLampState(true);
   } else {
     publishLampState(false);
   }
 }
-}  // namespace departure_button_lamp_manager
+} // namespace departure_button_lamp_manager
 
 #include "rclcpp_components/register_node_macro.hpp"
 
-RCLCPP_COMPONENTS_REGISTER_NODE(departure_button_lamp_manager::DepartureButtonLampManager)
+RCLCPP_COMPONENTS_REGISTER_NODE(
+    departure_button_lamp_manager::DepartureButtonLampManager)

--- a/departure_button_lamp_manager/test/test_departure_button_lamp_manager.cpp
+++ b/departure_button_lamp_manager/test/test_departure_button_lamp_manager.cpp
@@ -23,27 +23,27 @@
 using autoware_state_machine_msgs::msg::StateMachine;
 using dio_ros_driver::msg::DIOPort;
 
-class DepartureButtonLampManagerTest : public ::testing::Test
-{
+class DepartureButtonLampManagerTest : public ::testing::Test {
 protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     rclcpp::init(0, nullptr);
-    node_ = std::make_shared<departure_button_lamp_manager::DepartureButtonLampManager>(
-      rclcpp::NodeOptions());
+    node_ = std::make_shared<
+        departure_button_lamp_manager::DepartureButtonLampManager>(
+        rclcpp::NodeOptions());
 
     auto qos = rclcpp::QoS(10).reliable().transient_local();
 
-    pub_ = node_->create_publisher<StateMachine>("autoware_state_machine/state", qos);
+    pub_ = node_->create_publisher<StateMachine>("autoware_state_machine/state",
+                                                 qos);
     sub_ = node_->create_subscription<DIOPort>(
-      "button_lamp_out", qos,
-      [this](DIOPort::SharedPtr msg) { received_messages_.push_back(*msg); });
+        "button_lamp_out", qos,
+        [this](DIOPort::SharedPtr msg) { received_messages_.push_back(*msg); });
   }
 
   void TearDown() override { rclcpp::shutdown(); }
 
-  void sendAndCheckMessage(uint16_t service_state, uint8_t control_state, bool expected_value)
-  {
+  void sendAndCheckMessage(uint16_t service_state, uint8_t control_state,
+                           bool expected_value) {
     received_messages_.clear();
 
     StateMachine msg;
@@ -53,18 +53,20 @@ protected:
 
     auto start_time = std::chrono::steady_clock::now();
     while (received_messages_.empty() &&
-           std::chrono::steady_clock::now() - start_time < std::chrono::seconds(2)) {
+           std::chrono::steady_clock::now() - start_time <
+               std::chrono::seconds(2)) {
       rclcpp::spin_some(node_);
     }
 
     ASSERT_FALSE(received_messages_.empty())
-      << "Message not received for service_state=" << service_state
-      << ", control_state=" << control_state;
+        << "Message not received for service_state=" << service_state
+        << ", control_state=" << control_state;
 
     bool actual_value = received_messages_.front().value;
     EXPECT_EQ(actual_value, expected_value)
-      << "service_state=" << service_state << ", control_state=" << control_state
-      << ", expected=" << expected_value << ", actual=" << actual_value;
+        << "service_state=" << service_state
+        << ", control_state=" << control_state
+        << ", expected=" << expected_value << ", actual=" << actual_value;
   }
 
   rclcpp::Node::SharedPtr node_;
@@ -73,46 +75,43 @@ protected:
   std::vector<DIOPort> received_messages_;
 };
 
-TEST_F(DepartureButtonLampManagerTest, TestAllStateCombinations)
-{
+TEST_F(DepartureButtonLampManagerTest, TestAllStateCombinations) {
   {
     const std::vector<uint16_t> service_states = {
-      StateMachine::STATE_UNDEFINED,
-      StateMachine::STATE_DURING_WAKEUP,
-      StateMachine::STATE_DURING_CLOSE,
-      StateMachine::STATE_CHECK_NODE_ALIVE,
-      StateMachine::STATE_DURING_RECEIVE_ROUTE,
-      StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION,
-      StateMachine::STATE_WAITING_CALL_PERMISSION,
-      StateMachine::STATE_RUNNING,
-      StateMachine::STATE_INFORM_ENGAGE,
-      StateMachine::STATE_RUNNING_TOWARD_STOP_LINE,
-      StateMachine::STATE_RUNNING_TOWARD_OBSTACLE,
-      StateMachine::STATE_INSTRUCT_ENGAGE,
-      StateMachine::STATE_TURNING_LEFT,
-      StateMachine::STATE_TURNING_RIGHT,
-      StateMachine::STATE_DURING_OBSTACLE_AVOIDANCE,
-      StateMachine::STATE_STOP_DUETO_TRAFFIC_CONDITION,
-      StateMachine::STATE_STOP_DUETO_APPROACHING_OBSTACLE,
-      StateMachine::STATE_STOP_DUETO_SURROUNDING_PROXIMITY,
-      StateMachine::STATE_INFORM_RESTART,
-      StateMachine::STATE_ARRIVED_GOAL,
-      StateMachine::STATE_EMERGENCY_STOP
-    };
+        StateMachine::STATE_UNDEFINED,
+        StateMachine::STATE_DURING_WAKEUP,
+        StateMachine::STATE_DURING_CLOSE,
+        StateMachine::STATE_CHECK_NODE_ALIVE,
+        StateMachine::STATE_DURING_RECEIVE_ROUTE,
+        StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION,
+        StateMachine::STATE_WAITING_CALL_PERMISSION,
+        StateMachine::STATE_RUNNING,
+        StateMachine::STATE_INFORM_ENGAGE,
+        StateMachine::STATE_RUNNING_TOWARD_STOP_LINE,
+        StateMachine::STATE_RUNNING_TOWARD_OBSTACLE,
+        StateMachine::STATE_INSTRUCT_ENGAGE,
+        StateMachine::STATE_TURNING_LEFT,
+        StateMachine::STATE_TURNING_RIGHT,
+        StateMachine::STATE_DURING_OBSTACLE_AVOIDANCE,
+        StateMachine::STATE_STOP_DUETO_TRAFFIC_CONDITION,
+        StateMachine::STATE_STOP_DUETO_APPROACHING_OBSTACLE,
+        StateMachine::STATE_STOP_DUETO_SURROUNDING_PROXIMITY,
+        StateMachine::STATE_INFORM_RESTART,
+        StateMachine::STATE_ARRIVED_GOAL,
+        StateMachine::STATE_EMERGENCY_STOP};
 
-    const std::vector<uint8_t> control_states = {
-      StateMachine::MANUAL, 
-      StateMachine::AUTO
-    };
+    const std::vector<uint8_t> control_states = {StateMachine::MANUAL,
+                                                 StateMachine::AUTO};
 
     for (auto service_state : service_states) {
       for (auto control_state : control_states) {
-        bool expected_value =
-          !((service_state == StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION ||
-            service_state == StateMachine::STATE_WAITING_CALL_PERMISSION)&& control_state == StateMachine::AUTO);
-        sendAndCheckMessage(
-          static_cast<uint16_t>(service_state), static_cast<uint8_t>(control_state),
-          expected_value);
+        bool expected_value = !(
+            (service_state == StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION ||
+             service_state == StateMachine::STATE_WAITING_CALL_PERMISSION) &&
+            control_state == StateMachine::AUTO);
+        sendAndCheckMessage(static_cast<uint16_t>(service_state),
+                            static_cast<uint8_t>(control_state),
+                            expected_value);
       }
     }
   }


### PR DESCRIPTION
# Description
パッケージ単体リポジトリでのbuildとtestを実行するbuild-and-test workflowを追加しました（pre-commitに関しては後ほど別PR）。
workflowの追加にあたってリポジトリ内の構成変更を行っています。


pull requestが行われた際に、autowareで標準的に用いられている以下のアクションを利用したbuild-and-test workflowを実行をします。
https://github.com/autowarefoundation/autoware-github-actions/tree/main/colcon-build
https://github.com/autowarefoundation/autoware-github-actions/tree/main/colcon-test


# Related Links
- Jira [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/AEAP-1959)

# Test
<details>
<summary>pull requestを作成した際にbuild-and-test workflowが実行され、正常に完了していることを確認
</summary>

https://github.com/masahiro-kubota/departure_button_lamp_manager/pull/4
![image](https://github.com/user-attachments/assets/774ffc5f-ff33-45c2-919b-c003092b5cc5)
</details>

<details>
<summary>ビルドが失敗するときにbuildワークフローが失敗することを確認
</summary>

https://github.com/masahiro-kubota/departure_button_lamp_manager/pull/5
![image](https://github.com/user-attachments/assets/26060b42-00fb-4468-a6bd-5e42b13e57c3)
</details>

<details>
<summary>colcon testが失敗するときにtestワークフローが失敗することを確認
</summary>

https://github.com/masahiro-kubota/departure_button_lamp_manager/pull/6
![image](https://github.com/user-attachments/assets/de28831c-f021-433e-912b-1964ed427c66)
</details>

<details>
<summary>リポジトリ内の構成変更の影響を調べるために、launchファイルからノードを起動できることを確認
</summary>

![image](https://github.com/user-attachments/assets/c1339560-72fa-47c5-a75c-666f1e7f5dde)
</details>
