### PR TITLE
feat: remove unused subscription and related logic and add unit tests

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -13,15 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro: [humble]
-        image: ["ros:humble"]
+        image: [ros:humble]
         build-depends-repos: [build_depends.repos]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          repository: ${{ github.event.pull_request.head.repo.full_name }}  
-          ref: ${{ github.event.pull_request.head.ref }}  
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
@@ -34,7 +34,7 @@ jobs:
         run: |
           apt-get update -yqq
           apt-get install -yqq libboost-system-dev libboost-filesystem-dev libboost-thread-dev
-      
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # departure_button_lamp_manager
 
 ## Overview
+
 This node controls departure LED lamp for logistics workers turough `/dio_ros_driver` to inform if the vehicle is able to departure.
 
-# Input and Output
+### Input and Output
 
 - Input
-    - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine_msgs/tree/main)
-    - `/autoware_state_machine/state` \[[autoware_state_machine_msgs/msg/StateMachine](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateMachine.msg)\]:<br>State of the system.
+  - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine_msgs/tree/main)
+  - `/autoware_state_machine/state` \[[autoware_state_machine_msgs/msg/StateMachine](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateMachine.msg)\]:<br>State of the system.
 - output
   - to [dio_ros_driver](https://github.com/tier4/dio_ros_driver/)
-    - `/dio/dout4`  \[[dio_ros_driver/msg/DIOPort](https://github.com/tier4/dio_ros_driver/blob/develop/ros2/msg/DIOPort.msg)\]:<br>GPIO output topic for departure lamp. (this topic is remapping from button_lamp_out)
+    - `/dio/dout4` \[[dio_ros_driver/msg/DIOPort](https://github.com/tier4/dio_ros_driver/blob/develop/ros2/msg/DIOPort.msg)\]:<br>GPIO output topic for departure lamp. (this topic is remapping from button_lamp_out)
+
 ## Node Graph
 
 ![node graph](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/eve-autonomy/departure_button_lamp_manager/main/docs/node_graph.pu)
-

--- a/departure_button_lamp_manager/CMakeLists.txt
+++ b/departure_button_lamp_manager/CMakeLists.txt
@@ -42,7 +42,7 @@ rclcpp_components_register_node(departure_button_lamp_manager
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(rclcpp REQUIRED)
-  find_package(autoware_state_machine_msgs REQUIRED)
+  # find_package(autoware_state_machine_msgs REQUIRED)
   find_package(dio_ros_driver REQUIRED)
 
   ament_add_gtest(test_departure_button_lamp_manager

--- a/departure_button_lamp_manager/CMakeLists.txt
+++ b/departure_button_lamp_manager/CMakeLists.txt
@@ -66,4 +66,3 @@ ament_export_dependencies(
 ament_auto_package(INSTALL_TO_SHARE
   launch
 )
-

--- a/departure_button_lamp_manager/CMakeLists.txt
+++ b/departure_button_lamp_manager/CMakeLists.txt
@@ -49,12 +49,17 @@ if(BUILD_TESTING)
     test/test_departure_button_lamp_manager.cpp)
   target_link_libraries(test_departure_button_lamp_manager
     departure_button_lamp_manager rclcpp::rclcpp)
+  # ament_target_dependencies(test_departure_button_lamp_manager
+  #   autoware_state_machine_msgs dio_ros_driver)
   ament_target_dependencies(test_departure_button_lamp_manager
-    autoware_state_machine_msgs dio_ros_driver)
+    dio_ros_driver)
 endif()
 
+# ament_export_dependencies(
+#   autoware_state_machine_msgs dio_ros_driver
+#   )
 ament_export_dependencies(
-  autoware_state_machine_msgs dio_ros_driver
+  dio_ros_driver
   )
 
 

--- a/departure_button_lamp_manager/include/departure_button_lamp_manager/departure_button_lamp_manager.hpp
+++ b/departure_button_lamp_manager/include/departure_button_lamp_manager/departure_button_lamp_manager.hpp
@@ -19,15 +19,15 @@
 #include "rclcpp/rclcpp.hpp"
 
 // sub input
-#include "autoware_adapi_v1_msgs/msg/route_state.hpp"
-#include "autoware_adapi_v1_msgs/msg/route.hpp"
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
+#include "autoware_adapi_v1_msgs/msg/route.hpp"
+#include "autoware_adapi_v1_msgs/msg/route_state.hpp"
 
 namespace departure_button_lamp_manager
 {
-  using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
-  using Route = autoware_adapi_v1_msgs::msg::Route;
-  using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
+using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
+using Route = autoware_adapi_v1_msgs::msg::Route;
+using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
 
 class DepartureButtonLampManager : public rclcpp::Node
 {
@@ -56,7 +56,7 @@ private:
   void publishLampState(const bool value);
   void lampManager();
 
-  //member variables
+  // member variables
   uint16_t state_;
   Route route_;
   uint8_t mode_;

--- a/departure_button_lamp_manager/include/departure_button_lamp_manager/departure_button_lamp_manager.hpp
+++ b/departure_button_lamp_manager/include/departure_button_lamp_manager/departure_button_lamp_manager.hpp
@@ -22,14 +22,12 @@
 #include "autoware_adapi_v1_msgs/msg/route_state.hpp"
 #include "autoware_adapi_v1_msgs/msg/route.hpp"
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
-#include "eve_cmd_gate_msgs/msg/engage_request_state.hpp"
 
 namespace departure_button_lamp_manager
 {
   using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
   using Route = autoware_adapi_v1_msgs::msg::Route;
   using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
-  using AutonomousDrivingStartButton =eve_cmd_gate_msgs::msg::EngageRequestState;
 
 class DepartureButtonLampManager : public rclcpp::Node
 {
@@ -47,13 +45,11 @@ private:
   rclcpp::Subscription<RouteState>::SharedPtr sub_routing_state_;
   rclcpp::Subscription<Route>::SharedPtr sub_routing_route_;
   rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_state_;
-  rclcpp::Subscription<AutonomousDrivingStartButton>::SharedPtr sub_autonomous_driving_start_button_;
 
   // Callback
   void onState(const RouteState::ConstSharedPtr msg);
   void onRoute(const Route::ConstSharedPtr msg);
   void onOperationModeState(const OperationModeState::ConstSharedPtr msg);
-  void onAutonomousDrivingStartButton(const AutonomousDrivingStartButton::ConstSharedPtr msg);
 
   bool active_polarity_;
 
@@ -66,8 +62,6 @@ private:
   uint8_t mode_;
   bool is_autoware_control_;
   bool is_in_transition_;
-  bool is_accept_;
-  bool is_request_;
 };
 
 }  // namespace departure_button_lamp_manager

--- a/departure_button_lamp_manager/launch/departure_button_lamp_manager.launch.xml
+++ b/departure_button_lamp_manager/launch/departure_button_lamp_manager.launch.xml
@@ -13,11 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
 <launch>
-
   <node pkg="departure_button_lamp_manager" exec="departure_button_lamp_manager_node" name="departure_button_lamp_manager" output="screen">
-    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)" />
-    <remap from="button_lamp_out" to="/dio/dout4" />
+    <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>
+    <remap from="button_lamp_out" to="/dio/dout4"/>
   </node>
 </launch>

--- a/departure_button_lamp_manager/package.xml
+++ b/departure_button_lamp_manager/package.xml
@@ -24,11 +24,11 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>dio_ros_driver</depend>
-  <depend>rclcpp_components</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>builtin_interfaces</depend>
+  <depend>dio_ros_driver</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/departure_button_lamp_manager/package.xml
+++ b/departure_button_lamp_manager/package.xml
@@ -26,11 +26,8 @@
 
   <depend>rclcpp</depend>
   <depend>dio_ros_driver</depend>
-  <depend>autoware_state_machine_msgs</depend>
   <depend>rclcpp_components</depend>
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>eve_cmd_gate_msgs</depend>
- 
   <depend>builtin_interfaces</depend>
 
   <export>

--- a/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp
+++ b/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp
@@ -36,10 +36,6 @@ DepartureButtonLampManager::DepartureButtonLampManager(
     "/api/operation_mode/state", rclcpp::QoS(1).transient_local(),
     std::bind(&DepartureButtonLampManager::onOperationModeState, this, std::placeholders::_1));
 
-  sub_autonomous_driving_start_button_ = this->create_subscription<AutonomousDrivingStartButton>(
-    "/eve_cmd_gate/engage_request_state",rclcpp::QoS(1).transient_local(),
-    std::bind(&DepartureButtonLampManager::onAutonomousDrivingStartButton, this, std::placeholders::_1)); 
-
   // publisher
   pub_departure_button_lamp_ = this->create_publisher<dio_ros_driver::msg::DIOPort>(
     "button_lamp_out", rclcpp::QoS{3}.transient_local());
@@ -69,14 +65,6 @@ void DepartureButtonLampManager::onOperationModeState(const OperationModeState::
   lampManager();
 }
 
-void DepartureButtonLampManager::onAutonomousDrivingStartButton(const AutonomousDrivingStartButton::ConstSharedPtr msg)
-{
-  is_accept_ = msg ->is_engage_accepted;
-  is_request_ = msg ->is_engage_requesting;
-  lampManager();
-}
-
-
 void DepartureButtonLampManager::publishLampState(const bool value)
 {
   dio_ros_driver::msg::DIOPort msg;
@@ -87,21 +75,14 @@ void DepartureButtonLampManager::publishLampState(const bool value)
 
 void DepartureButtonLampManager::lampManager()
 {
-  bool autoDrigingReadyForDeparture_flg = false;
-  if (state_ == autoware_adapi_v1_msgs::msg::RouteState::SET) {
-    if (route_.data.size() != 0) {
-      if (is_autoware_control_ && !is_in_transition_ && mode_ != OperationModeState::AUTONOMOUS ) {
-          if (!is_accept_ && !is_request_) {
-            autoDrigingReadyForDeparture_flg = true;
-          }
-      }
-    }
-  }
-  if (autoDrigingReadyForDeparture_flg) {
-    publishLampState(true);
-  } else {
-    publishLampState(false);
-  }
+  const bool is_ready =
+    state_ == autoware_adapi_v1_msgs::msg::RouteState::SET &&
+    !route_.data.empty() &&
+    is_autoware_control_ &&
+    !is_in_transition_ &&
+    mode_ != OperationModeState::AUTONOMOUS;
+
+  publishLampState(is_ready);
 }
 }  // namespace departure_button_lamp_manager
 

--- a/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp
+++ b/departure_button_lamp_manager/src/departure_button_lamp_manager.cpp
@@ -13,6 +13,7 @@
 // limitations under the License
 
 #include <departure_button_lamp_manager/departure_button_lamp_manager.hpp>
+
 #include <fstream>
 
 namespace departure_button_lamp_manager
@@ -43,7 +44,10 @@ DepartureButtonLampManager::DepartureButtonLampManager(
   active_polarity_ = ACTIVE_POLARITY;
 }
 
-DepartureButtonLampManager::~DepartureButtonLampManager() { publishLampState(false); }
+DepartureButtonLampManager::~DepartureButtonLampManager()
+{
+  publishLampState(false);
+}
 
 void DepartureButtonLampManager::onState(const RouteState::ConstSharedPtr msg)
 {
@@ -59,9 +63,9 @@ void DepartureButtonLampManager::onRoute(const Route::ConstSharedPtr msg)
 
 void DepartureButtonLampManager::onOperationModeState(const OperationModeState::ConstSharedPtr msg)
 {
-  is_autoware_control_ = msg ->is_autoware_control_enabled;
-  is_in_transition_ = msg ->is_in_transition;
-  mode_ = msg ->mode;
+  is_autoware_control_ = msg->is_autoware_control_enabled;
+  is_in_transition_ = msg->is_in_transition;
+  mode_ = msg->mode;
   lampManager();
 }
 
@@ -75,12 +79,9 @@ void DepartureButtonLampManager::publishLampState(const bool value)
 
 void DepartureButtonLampManager::lampManager()
 {
-  const bool is_ready =
-    state_ == autoware_adapi_v1_msgs::msg::RouteState::SET &&
-    !route_.data.empty() &&
-    is_autoware_control_ &&
-    !is_in_transition_ &&
-    mode_ != OperationModeState::AUTONOMOUS;
+  const bool is_ready = state_ == autoware_adapi_v1_msgs::msg::RouteState::SET &&
+                        !route_.data.empty() && is_autoware_control_ && !is_in_transition_ &&
+                        mode_ != OperationModeState::AUTONOMOUS;
 
   publishLampState(is_ready);
 }

--- a/departure_button_lamp_manager/test/test_departure_button_lamp_manager.cpp
+++ b/departure_button_lamp_manager/test/test_departure_button_lamp_manager.cpp
@@ -14,14 +14,18 @@
 
 #include <gtest/gtest.h>
 
-#include <autoware_state_machine_msgs/msg/state_machine.hpp>
-#include <dio_ros_driver/msg/dio_port.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <dio_ros_driver/msg/dio_port.hpp>
+#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/route.hpp>
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 
 #include "departure_button_lamp_manager/departure_button_lamp_manager.hpp"
 
-using autoware_state_machine_msgs::msg::StateMachine;
-using dio_ros_driver::msg::DIOPort;
+using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
+using Route = autoware_adapi_v1_msgs::msg::Route;
+using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
+using DIOPort = dio_ros_driver::msg::DIOPort;
 
 class DepartureButtonLampManagerTest : public ::testing::Test
 {
@@ -32,9 +36,12 @@ protected:
     node_ = std::make_shared<departure_button_lamp_manager::DepartureButtonLampManager>(
       rclcpp::NodeOptions());
 
-    auto qos = rclcpp::QoS(10).reliable().transient_local();
+    auto qos = rclcpp::QoS(1).reliable().transient_local();
 
-    pub_ = node_->create_publisher<StateMachine>("autoware_state_machine/state", qos);
+    pub_route_state_ = node_->create_publisher<RouteState>("/api/routing/state", qos);
+    pub_route_ = node_->create_publisher<Route>("/api/routing/route", qos);
+    pub_operation_mode_ = node_->create_publisher<OperationModeState>("/api/operation_mode/state", qos);
+
     sub_ = node_->create_subscription<DIOPort>(
       "button_lamp_out", qos,
       [this](DIOPort::SharedPtr msg) { received_messages_.push_back(*msg); });
@@ -42,78 +49,139 @@ protected:
 
   void TearDown() override { rclcpp::shutdown(); }
 
-  void sendAndCheckMessage(uint16_t service_state, uint8_t control_state, bool expected_value)
+  void spinUntilMessage()
   {
-    received_messages_.clear();
-
-    StateMachine msg;
-    msg.service_layer_state = service_state;
-    msg.control_layer_state = control_state;
-    pub_->publish(msg);
-
     auto start_time = std::chrono::steady_clock::now();
     while (received_messages_.empty() &&
            std::chrono::steady_clock::now() - start_time < std::chrono::seconds(2)) {
       rclcpp::spin_some(node_);
     }
+  }
 
-    ASSERT_FALSE(received_messages_.empty())
-      << "Message not received for service_state=" << service_state
-      << ", control_state=" << control_state;
+  void publishState(uint16_t state)
+  {
+    RouteState msg;
+    msg.state = state;
+    pub_route_state_->publish(msg);
+  }
 
-    bool actual_value = received_messages_.front().value;
-    EXPECT_EQ(actual_value, expected_value)
-      << "service_state=" << service_state << ", control_state=" << control_state
-      << ", expected=" << expected_value << ", actual=" << actual_value;
+  void publishRoute(bool has_data)
+  {
+    Route msg;
+    if (has_data) {
+      autoware_adapi_v1_msgs::msg::RouteData route_data;
+      msg.data.push_back(route_data);
+    }
+    pub_route_->publish(msg);
+  }
+
+  void publishOperationMode(bool is_autoware_control, bool is_in_transition, uint8_t mode)
+  {
+    OperationModeState msg;
+    msg.is_autoware_control_enabled = is_autoware_control;
+    msg.is_in_transition = is_in_transition;
+    msg.mode = mode;
+    pub_operation_mode_->publish(msg);
   }
 
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Publisher<StateMachine>::SharedPtr pub_;
+  rclcpp::Publisher<RouteState>::SharedPtr pub_route_state_;
+  rclcpp::Publisher<Route>::SharedPtr pub_route_;
+  rclcpp::Publisher<OperationModeState>::SharedPtr pub_operation_mode_;
   rclcpp::Subscription<DIOPort>::SharedPtr sub_;
   std::vector<DIOPort> received_messages_;
 };
 
-TEST_F(DepartureButtonLampManagerTest, TestAllStateCombinations)
+// ランプが点灯する条件：
+// - state_ == RouteState::SET
+// - !route_.data.empty()
+// - is_autoware_control_
+// - !is_in_transition_
+// - mode_ != OperationModeState::AUTONOMOUS
+// ACTIVE_POLARITY = false なので、value は反転される
+
+TEST_F(DepartureButtonLampManagerTest, LampOnWhenAllConditionsMet)
 {
-  {
-    const std::vector<uint16_t> service_states = {
-      StateMachine::STATE_UNDEFINED,
-      StateMachine::STATE_DURING_WAKEUP,
-      StateMachine::STATE_DURING_CLOSE,
-      StateMachine::STATE_CHECK_NODE_ALIVE,
-      StateMachine::STATE_DURING_RECEIVE_ROUTE,
-      StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION,
-      StateMachine::STATE_WAITING_CALL_PERMISSION,
-      StateMachine::STATE_RUNNING,
-      StateMachine::STATE_INFORM_ENGAGE,
-      StateMachine::STATE_RUNNING_TOWARD_STOP_LINE,
-      StateMachine::STATE_RUNNING_TOWARD_OBSTACLE,
-      StateMachine::STATE_INSTRUCT_ENGAGE,
-      StateMachine::STATE_TURNING_LEFT,
-      StateMachine::STATE_TURNING_RIGHT,
-      StateMachine::STATE_DURING_OBSTACLE_AVOIDANCE,
-      StateMachine::STATE_STOP_DUETO_TRAFFIC_CONDITION,
-      StateMachine::STATE_STOP_DUETO_APPROACHING_OBSTACLE,
-      StateMachine::STATE_STOP_DUETO_SURROUNDING_PROXIMITY,
-      StateMachine::STATE_INFORM_RESTART,
-      StateMachine::STATE_ARRIVED_GOAL,
-      StateMachine::STATE_EMERGENCY_STOP
-    };
+  received_messages_.clear();
 
-    const std::vector<uint8_t> control_states = {
-      StateMachine::MANUAL, 
-      StateMachine::AUTO
-    };
+  publishRoute(true);
+  publishOperationMode(true, false, OperationModeState::STOP);
+  publishState(RouteState::SET);
 
-    for (auto service_state : service_states) {
-      for (auto control_state : control_states) {
-        bool expected_value =
-          !((service_state == StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION ||
-            service_state == StateMachine::STATE_WAITING_CALL_PERMISSION)&& control_state == StateMachine::AUTO);
-        sendAndCheckMessage(
-          static_cast<uint16_t>(service_state), static_cast<uint8_t>(control_state),
-          expected_value);
-      }
-    }
-  }
+  spinUntilMessage();
+
+  ASSERT_FALSE(received_messages_.empty());
+  // ACTIVE_POLARITY = false なので、is_ready=true のとき value=false
+  EXPECT_FALSE(received_messages_.back().value);
+}
+
+TEST_F(DepartureButtonLampManagerTest, LampOffWhenRouteNotSet)
+{
+  received_messages_.clear();
+
+  publishRoute(true);
+  publishOperationMode(true, false, OperationModeState::STOP);
+  publishState(RouteState::UNSET);
+
+  spinUntilMessage();
+
+  ASSERT_FALSE(received_messages_.empty());
+  // ACTIVE_POLARITY = false なので、is_ready=false のとき value=true
+  EXPECT_TRUE(received_messages_.back().value);
+}
+
+TEST_F(DepartureButtonLampManagerTest, LampOffWhenRouteEmpty)
+{
+  received_messages_.clear();
+
+  publishRoute(false);
+  publishOperationMode(true, false, OperationModeState::STOP);
+  publishState(RouteState::SET);
+
+  spinUntilMessage();
+
+  ASSERT_FALSE(received_messages_.empty());
+  EXPECT_TRUE(received_messages_.back().value);
+}
+
+TEST_F(DepartureButtonLampManagerTest, LampOffWhenNotAutowareControl)
+{
+  received_messages_.clear();
+
+  publishRoute(true);
+  publishOperationMode(false, false, OperationModeState::STOP);
+  publishState(RouteState::SET);
+
+  spinUntilMessage();
+
+  ASSERT_FALSE(received_messages_.empty());
+  EXPECT_TRUE(received_messages_.back().value);
+}
+
+TEST_F(DepartureButtonLampManagerTest, LampOffWhenInTransition)
+{
+  received_messages_.clear();
+
+  publishRoute(true);
+  publishOperationMode(true, true, OperationModeState::STOP);
+  publishState(RouteState::SET);
+
+  spinUntilMessage();
+
+  ASSERT_FALSE(received_messages_.empty());
+  EXPECT_TRUE(received_messages_.back().value);
+}
+
+TEST_F(DepartureButtonLampManagerTest, LampOffWhenAutonomousMode)
+{
+  received_messages_.clear();
+
+  publishRoute(true);
+  publishOperationMode(true, false, OperationModeState::AUTONOMOUS);
+  publishState(RouteState::SET);
+
+  spinUntilMessage();
+
+  ASSERT_FALSE(received_messages_.empty());
+  EXPECT_TRUE(received_messages_.back().value);
 }

--- a/departure_button_lamp_manager/test/test_departure_button_lamp_manager.cpp
+++ b/departure_button_lamp_manager/test/test_departure_button_lamp_manager.cpp
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
+#include "departure_button_lamp_manager/departure_button_lamp_manager.hpp"
+
+#include <dio_ros_driver/msg/dio_port.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/route.hpp>
+#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
+
 #include <gtest/gtest.h>
 
-#include <rclcpp/rclcpp.hpp>
-#include <dio_ros_driver/msg/dio_port.hpp>
-#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
-#include <autoware_adapi_v1_msgs/msg/route.hpp>
-#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-
-#include "departure_button_lamp_manager/departure_button_lamp_manager.hpp"
+#include <memory>
+#include <vector>
 
 using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
 using Route = autoware_adapi_v1_msgs::msg::Route;
@@ -40,7 +44,8 @@ protected:
 
     pub_route_state_ = node_->create_publisher<RouteState>("/api/routing/state", qos);
     pub_route_ = node_->create_publisher<Route>("/api/routing/route", qos);
-    pub_operation_mode_ = node_->create_publisher<OperationModeState>("/api/operation_mode/state", qos);
+    pub_operation_mode_ =
+      node_->create_publisher<OperationModeState>("/api/operation_mode/state", qos);
 
     sub_ = node_->create_subscription<DIOPort>(
       "button_lamp_out", qos,


### PR DESCRIPTION
# description
This pull request simplify its dependencies. The main changes include removing legacy message types and diagnostic handling, switching to a more maintainable state transition table, and updating emergency holding logic to use `HazardStatus`. Additionally, test infrastructure and dependencies are improved for easier validation.

# test
I checked

1. colcon test passed
2. warning_lamp and emergency_lamp status true/false of each states in Planning simulator.
